### PR TITLE
Make payload type match in both media description and attributes

### DIFF
--- a/voip_utils/sip.py
+++ b/voip_utils/sip.py
@@ -153,7 +153,7 @@ class SipDatagramProtocol(asyncio.DatagramProtocol, ABC):
             f"c=IN IP4 {call_info.server_ip}",
             "t=0 0",
             f"m=audio {server_rtp_port} RTP/AVP {self._opus_payload}",
-            f"a=rtpmap:{_OPUS_PAYLOAD} opus/48000/2",
+            f"a=rtpmap:{self._opus_payload} opus/48000/2",
             "a=ptime:20",
             "a=maxptime:150",
             "a=sendrecv",


### PR DESCRIPTION
Fixes mismatch between media description and attribute. I.e. if 96 was mutually agreed upon it should be 96 in both and not 96 in one and 123 in the other.