### PR TITLE
Pass payload type in CallInfo

### DIFF
--- a/voip_utils/const.py
+++ b/voip_utils/const.py
@@ -1,0 +1,3 @@
+"""VoIP constants."""
+
+OPUS_PAYLOAD_TYPE = 123  # Default GrandStream payload type

--- a/voip_utils/rtp_audio.py
+++ b/voip_utils/rtp_audio.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import opuslib
 
+from .const import OPUS_PAYLOAD_TYPE
 from .error import RtpError
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +23,7 @@ class RtpOpusInput:
     opus_width: int = 2  # bytes
     opus_channels: int = 2
     opus_frame_size: int = 960  # samples per channel
-    opus_payload: int = 123  # set by GrandStream
+    opus_payload_type: int = OPUS_PAYLOAD_TYPE  # set by GrandStream
 
     def __post_init__(
         self,
@@ -56,9 +57,9 @@ class RtpOpusInput:
             raise RtpError("Padding and extension headers not supported")
 
         payload_type &= 0x7F  # Remove marker bit
-        if payload_type != self.opus_payload:
+        if payload_type != self.opus_payload_type:
             raise RtpError(
-                f"Expected payload type {self.opus_payload}, got {payload_type}"
+                f"Expected payload type {self.opus_payload_type}, got {payload_type}"
             )
 
         # Assume no padding, extension headers, etc.
@@ -114,7 +115,7 @@ class RtpOpusOutput:
     opus_width: int = 2  # bytes
     opus_channels: int = 2
     opus_frame_size: int = 960  # samples per channel
-    opus_payload: int = 123  # set by GrandStream
+    opus_payload_type: int = OPUS_PAYLOAD_TYPE  # set by GrandStream
     opus_bytes_per_frame: int = 960 * 2 * 2  # 16-bit x stereo
 
     _rtp_flags: int = 0b10000000  # v2, no padding/extensions/CSRCs
@@ -221,7 +222,7 @@ class RtpOpusOutput:
             rtp_bytes = struct.pack(
                 ">BBHLL",
                 self._rtp_flags,
-                self.opus_payload,
+                self.opus_payload_type,
                 self._rtp_sequence_num,
                 self._rtp_timestamp,
                 self._rtp_ssrc,

--- a/voip_utils/voip.py
+++ b/voip_utils/voip.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from functools import partial
 from typing import Any, Callable, Optional, Set
 
+from .const import OPUS_PAYLOAD_TYPE
 from .rtp_audio import RtpOpusInput, RtpOpusOutput
 from .sip import CallInfo, SdpInfo, SipDatagramProtocol
 
@@ -80,6 +81,7 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
         rate: int = 16000,
         width: int = 2,
         channels: int = 1,
+        opus_payload_type: int = OPUS_PAYLOAD_TYPE,
     ) -> None:
         """Set up RTP server."""
         # Desired format for input audio
@@ -91,8 +93,8 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
         self.addr = None
 
         self._audio_queue: "asyncio.Queue[bytes]" = asyncio.Queue()
-        self._rtp_input = RtpOpusInput()
-        self._rtp_output = RtpOpusOutput()
+        self._rtp_input = RtpOpusInput(opus_payload_type=opus_payload_type)
+        self._rtp_output = RtpOpusOutput(opus_payload_type=opus_payload_type)
         self._is_connected: bool = False
 
     def disconnect(self):


### PR DESCRIPTION
Detect OPUS payload type in SIP, and pass this to RTP senders/receivers via CallInfo