### PR TITLE
Close RTP socket to free port for re-use

### DIFF
--- a/voip_utils/voip.py
+++ b/voip_utils/voip.py
@@ -72,6 +72,9 @@ class VoipDatagramProtocol(SipDatagramProtocol):
         # Tell caller to start sending/receiving RTP audio
         self.answer(call_info, rtp_port)
 
+        # Close socket to free port for re-use
+        sock.close()
+
 
 class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
     """Handle RTP audio input/output for a VoIP call."""


### PR DESCRIPTION
While troubleshooting inside a container without host networking, and setting the RTP bind port to a single port, I noticed the socket is never closed until you restart homeassistant.

The first call works, but then the second call fails with a `512` because the address is already in use.

It probably hasn't been noticed yet because it's randomly binding 1 of 65536 ports, but eventually your system will run out of ports unless we close them, and because it's random, at any point it could try to bind a port that it had already previously bound.

This change fixes it for me and I can place repeat calls without errors, but it feels strange to just put a close here without being in a callback, so if there is a better way to fix this, I'd be happy to learn :+1: 