### PR TITLE
Include URI for device identification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+---
+name: CI
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches: [main]
+
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - run: pip3 install  -r requirements.txt -r requirements_dev.txt
+      - run: pytest tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,6 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
-      - run: pip3 install  -r requirements.txt -r requirements_dev.txt
+      - run: script/setup
+      - run: script/lint
       - run: pytest tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">=3.9.0"
 dependencies = ["opuslib==3.0.1"]

--- a/script/setup
+++ b/script/setup
@@ -30,6 +30,7 @@ pip3 install --upgrade pip
 pip3 install --upgrade wheel setuptools
 
 pip3 install pre-commit -r "${base_dir}/requirements.txt"
+pip3 install pre-commit -r "${base_dir}/requirements_dev.txt"
 
 # -----------------------------------------------------------------------------
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for voip_utils."""

--- a/tests/test_sip.py
+++ b/tests/test_sip.py
@@ -1,0 +1,23 @@
+"""Test voip_utils SIP functionality."""
+import pytest
+from voip_utils.sip import SipDatagramProtocol
+
+def test_parse_header_for_uri():
+    endpoint, name = SipDatagramProtocol._parse_uri_header('"Test Name" <sip:12345@example.com>')
+    assert name == "Test Name"
+    assert endpoint == "sip:12345@example.com"
+
+def test_parse_header_for_uri_no_name():
+    endpoint, name = SipDatagramProtocol._parse_uri_header('sip:12345@example.com')
+    assert name is None
+    assert endpoint == "sip:12345@example.com"
+
+def test_parse_header_for_uri_sips():
+    endpoint, name = SipDatagramProtocol._parse_uri_header('"Test Name" <sips:12345@example.com>')
+    assert name == "Test Name"
+    assert endpoint == "sips:12345@example.com"
+
+def test_parse_header_for_uri_no_space_name():
+    endpoint, name = SipDatagramProtocol._parse_uri_header('Test <sip:12345@example.com>')
+    assert name == "Test"
+    assert endpoint == "sip:12345@example.com"


### PR DESCRIPTION
When receiving a call parse the SIP URI from the Contact or From header to use for identifying a device. Using the URI will make it possible to distinguish between multiple endpoints calling through a centralized server (such as Asterisk) which would otherwise appear to come from the same IP address. Keeping track of the Contact header URI will also make it possible to send outbound calls to the device using the correct URI.