### PR TITLE
Fix SIP header parsing

### DIFF
--- a/tests/test_sip.py
+++ b/tests/test_sip.py
@@ -30,6 +30,18 @@ def test_parse_header_for_uri_no_space_name():
     assert endpoint.uri == "sip:12345@example.com"
 
 
+def test_parse_header_for_uri_no_space_between_name():
+    endpoint = SipEndpoint("Test<sip:12345@example.com>")
+    assert endpoint.description == "Test"
+    assert endpoint.uri == "sip:12345@example.com"
+
+
+def test_parse_header_for_uri_no_space_between_quoted_name():
+    endpoint = SipEndpoint('"Test Endpoint"<sip:12345@example.com>')
+    assert endpoint.description == "Test Endpoint"
+    assert endpoint.uri == "sip:12345@example.com"
+
+
 def test_parse_header_for_uri_no_username():
     endpoint = SipEndpoint("Test <sip:example.com>")
     assert endpoint.description == "Test"

--- a/voip_utils/sip.py
+++ b/voip_utils/sip.py
@@ -44,7 +44,7 @@ class SipEndpoint:
 
     def __post_init__(self):
         header_pattern = re.compile(
-            r'\s*((?P<description>\b\w+\b|"[^"]+")\s+)?<?(?P<uri>sips?:[^>]+)>?.*'
+            r'\s*((?P<description>\b\w+\b|"[^"]+")\s*)?<?(?P<uri>sips?:[^>]+)>?.*'
         )
         header_match = header_pattern.match(self.sip_header)
         if header_match is not None:


### PR DESCRIPTION
Per https://www.ietf.org/rfc/rfc3261.txt section 20.10 Contact whitespace is not required between the display name and URI in SIP headers.