### PR TITLE
Compliant cancel message

### DIFF
--- a/tests/test_sip.py
+++ b/tests/test_sip.py
@@ -1,7 +1,9 @@
 """Test voip_utils SIP functionality."""
 
-from voip_utils.sip import SipEndpoint, get_sip_endpoint
+from voip_utils.sip import CallInfo, SdpInfo, SipDatagramProtocol, SipEndpoint, SipMessage, get_sip_endpoint
+from unittest.mock import Mock
 
+_CRLF = "\r\n"
 
 def test_parse_header_for_uri():
     endpoint = SipEndpoint('"Test Name" <sip:12345@example.com>')
@@ -84,3 +86,44 @@ def test_get_sip_endpoint_with_scheme():
     assert endpoint.description is None
     assert endpoint.username is None
     assert endpoint.uri == "sips:example.com"
+
+class MockSipDatagramProtocol(SipDatagramProtocol):
+    def on_call(self, call_info: CallInfo):
+        pass
+
+def test_cancel():
+    protocol = MockSipDatagramProtocol(SdpInfo("username", 5, "session", "version"))
+    source = get_sip_endpoint("testsource")
+    destination = get_sip_endpoint("destination")
+    invite_lines = [
+        f"INVITE {destination.uri} SIP/2.0",
+        f"Via: SIP/2.0/UDP {source.host}:{source.port}",
+        f"From: {source.sip_header}",
+        f"Contact: {source.sip_header}",
+        f"To: {destination.sip_header}",
+        f"Call-ID: 100",
+        "CSeq: 50 INVITE",
+        f"User-Agent: test-agent 1.0",
+        "Allow: INVITE, ACK, OPTIONS, CANCEL, BYE, SUBSCRIBE, NOTIFY, INFO, REFER, UPDATE",
+        "Accept: application/sdp, application/dtmf-relay",
+        "Content-Type: application/sdp",
+        "Content-Length: 0",
+        "",
+    ]
+    invite_text = _CRLF.join(invite_lines) + _CRLF
+    invite_msg = SipMessage.parse_sip(invite_text, False)
+
+    call_info = CallInfo(
+        caller_endpoint=destination,
+        local_endpoint=source,
+        caller_rtp_port=12345,
+        server_ip=source.host,
+        headers=invite_msg.headers,
+    )
+
+    transport = Mock()
+    protocol.connection_made(transport)
+    protocol.cancel_call(call_info)
+
+    transport.sendto.assert_called_once_with(b'CANCEL sip:destination SIP/2.0\r\nVia: SIP/2.0/UDP testsource:5060\r\nFrom: sip:testsource\r\nTo: sip:destination\r\nCall-ID: 100\r\nCSeq: 50 CANCEL\r\nUser-Agent: voip-utils 1.0\r\nContent-Length: 0\r\n\r\n', ('destination', 5060))
+

--- a/voip_utils/sip.py
+++ b/voip_utils/sip.py
@@ -309,7 +309,7 @@ class SipDatagramProtocol(asyncio.DatagramProtocol, ABC):
         if self.transport is None:
             raise RuntimeError("No transport available for sending hangup.")
 
-        call_id = get_header(call_info.headers, 'call-id')[1]
+        call_id = get_header(call_info.headers, "call-id")[1]
         bye_lines = [
             f"BYE {call_info.caller_endpoint.uri} SIP/2.0",
             f"Via: SIP/2.0/UDP {call_info.local_endpoint.host}:{call_info.local_endpoint.port}",


### PR DESCRIPTION
Make the cancel message more compliant with the SIP specification.

There are a set of headers in the Cancel request that are supposed to match the headers of the Invite request they are cancelling. Also processing of header names is supposed to be case insensitive, so I tried to handle that in the parts I added.