### PR TITLE
Handle empty lines at beginning of message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.3
+
+- Handle empty lines at start of message
+
+## 0.3.2
+
+- Compliant cancel message
+
 ## 0.3.1
 
 - Add cancel_call to stop ringing

--- a/tests/test_sip.py
+++ b/tests/test_sip.py
@@ -87,6 +87,63 @@ def test_get_sip_endpoint_with_scheme():
     assert endpoint.username is None
     assert endpoint.uri == "sips:example.com"
 
+def test_parse_freepbx_options():
+    options_lines = [
+        "",
+        "OPTIONS sip:10.5.1.2:5060 SIP/2.0"
+        "Via: SIP/2.0/UDP 10.5.1.3:5060;rport;branch=z9hG4bKPj67dd8ad6-5b27-4860-b9fb-8bae195d6443"
+        "From: <sip:HomeAssistant@10.5.1.3>;tag=bab3c78d-7659-466f-8326-61d6da0c5267"
+        "To: <sip:10.5.1.2>"
+        "Contact: <sip:999@10.5.1.3:5060>"
+        "Call-ID: 9aa75329-b33d-4e27-b2e3-73ab30677942"
+        "CSeq: 14010 OPTIONS"
+        "Max-Forwards: 70"
+        "User-Agent: FPBX-17.0.19.27(21.8.0)"
+        "Content-Length:  0"
+        "",
+    ]
+    options_text = _CRLF.join(options_lines) + _CRLF
+    options_msg = SipMessage.parse_sip(options_text, False)
+    assert options_msg is not None
+
+def test_parse_with_body():
+    invite_lines = [
+        "",
+        "INVITE sip:6002@192.168.0.18 SIP/2.0",
+        "Via: SIP/2.0/UDP 192.168.0.18:5062",
+        "From: sip:5000@192.168.0.18:5062",
+        "Contact: sip:5000@192.168.0.18:5062",
+        "To: sip:6002@192.168.0.18",
+        "Call-ID: 5443482144267586",
+        "CSeq: 50 INVITE",
+        "User-Agent: test-agent 1.0",
+        "Allow: INVITE, ACK, OPTIONS, CANCEL, BYE, SUBSCRIBE, NOTIFY, INFO, REFER, UPDATE",
+        "Accept: application/sdp, application/dtmf-relay",
+        "Content-Type: application/sdp",
+        "Content-Length: 391",
+        "",
+        "v=0",
+        "o=5000 5443482144267586 5443482144267586 IN IP4 192.168.0.18",
+        "s=Talk",
+        "c=IN IP4 192.168.0.18",
+        "t=0 0",
+        "m=audio 59756 RTP/AVP 123 96 101 103 104",
+        "a=sendrecv",
+        "a=rtpmap:96 opus/48000/2",
+        "a=fmtp:96 useinbandfec=0",
+        "a=rtpmap:123 opus/48000/2",
+        "a=fmtp:123 maxplaybackrate=16000",
+        "a=rtpmap:101 telephone-event/48000",
+        "a=rtpmap:103 telephone-event/16000",
+        "a=rtpmap:104 telephone-event/8000",
+        "a=ptime:20"
+    ]
+    invite_text = _CRLF.join(invite_lines) + _CRLF
+    invite_msg = SipMessage.parse_sip(invite_text, False)
+    assert invite_msg is not None
+    assert invite_msg.body is not None
+    assert invite_msg.body.startswith("v=0")
+
 class MockSipDatagramProtocol(SipDatagramProtocol):
     def on_call(self, call_info: CallInfo):
         pass

--- a/voip_utils/sip.py
+++ b/voip_utils/sip.py
@@ -96,24 +96,30 @@ class SipMessage:
         headers: dict[str, str] = {}
         offset: int = 0
 
+        first_line = True
+
         # See: https://datatracker.ietf.org/doc/html/rfc3261
         for i, line in enumerate(lines):
-            if line:
-                offset += len(line) + len(_CRLF)
-
-            if i == 0:
-                line_parts = line.split()
-                if line_parts[0].startswith("SIP"):
-                    protocol = line_parts[0]
-                    code = line_parts[1]
-                    reason = line_parts[2]
+            if first_line:
+                if line:
+                    offset += len(line) + len(_CRLF)
+                    line_parts = line.split()
+                    if line_parts[0].startswith("SIP"):
+                        protocol = line_parts[0]
+                        code = line_parts[1]
+                        reason = line_parts[2]
+                    else:
+                        method = line_parts[0]
+                        request_uri = line_parts[1]
+                        protocol = line_parts[2]
+                    first_line = False
                 else:
-                    method = line_parts[0]
-                    request_uri = line_parts[1]
-                    protocol = line_parts[2]
+                    offset += len(_CRLF)
             elif not line:
+                offset += len(_CRLF)
                 break
             else:
+                offset += len(line) + len(_CRLF)
                 key, value = line.split(":", maxsplit=1)
                 headers[key.lower() if header_lowercase else key] = value.strip()
 

--- a/voip_utils/sip.py
+++ b/voip_utils/sip.py
@@ -99,7 +99,7 @@ class SipMessage:
         first_line = True
 
         # See: https://datatracker.ietf.org/doc/html/rfc3261
-        for i, line in enumerate(lines):
+        for line in lines:
             if first_line:
                 if line:
                     offset += len(line) + len(_CRLF)


### PR DESCRIPTION
Handle empty lines that may be sent at the start of a SIP message.  This should address https://github.com/home-assistant-libs/voip-utils/issues/32.