### PR TITLE
Use header values for response host and port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.4
 
 - Add tag parameter to To header if missing
+- Use header values for response host and port
 
 ## 0.3.3
 


### PR DESCRIPTION
Use the values from the Via header for determining the host and port to send responses to. If the Via header can not be used fall back to the Contact header. If both the Via header and Contact header can not be used fall back to the peer host and port from the transport the message was received on.

The Contact header value is also being added to the CallInfo object. This should allow Home Assistant to save the associated URI to use for making outgoing calls, per https://datatracker.ietf.org/doc/html/rfc3261#section-8.1.1.8.