### PR TITLE
Cleanup RTP/RTCP servers on hangup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.5
+
+- Cleanup RTP/RTCP servers on hangup
+
 ## 0.3.4
 
 - Add tag parameter to To header if missing


### PR DESCRIPTION
After hanging up a call the RTP/RTCP servers created for that call should be shut down as they are no longer needed.