### PR TITLE
Improve RTP output scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.1
+
+- Move RTP audio output processing to separate task to maintain consistent schedule with silence sent when there is no active audio
+
 ## 0.4.0
 
 - Update to opuslib-next

--- a/call_example.py
+++ b/call_example.py
@@ -51,6 +51,7 @@ RTP_AUDIO_SETTINGS = {
     "sleep_ratio": 0.99,
 }
 
+
 class ExampleVoipDatagramProtocol(VoipDatagramProtocol):
 
     def __init__(
@@ -63,10 +64,10 @@ class ExampleVoipDatagramProtocol(VoipDatagramProtocol):
         super().__init__(sdp_info, valid_protocol_factory, invalid_protocol_factory)
         self.call_end = asyncio.Event()
 
-
     def on_hangup(self, call_info: CallInfo):
-        """Example implementation of on hangup. """
+        """Example implementation of on hangup."""
         self.call_end.set()
+
 
 class PreRecordMessageProtocol(RtpDatagramProtocol):
     """Plays a pre-recorded message on a loop."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,13 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.9.0"
+requires-python = ">=3.9.0,<3.15"
 dependencies = ["opuslib-next==1.1.6"]
 
 [project.optional-dependencies]
 dev = [
     "build==1.2.2",
-    "black==23.3.0",
+    "black==26.5.1",
     "flake8==7.1.0",
     "isort==5.12.0",
     "mypy==1.17.1",

--- a/voip_utils/rtp_audio.py
+++ b/voip_utils/rtp_audio.py
@@ -162,6 +162,33 @@ class RtpOpusOutput:
         # Change each time
         self._rtp_ssrc = random.randint(0, 2**32)
 
+    def silence_frame(self) -> bytes:
+        """Create RTP packet for silence frame."""
+        audio_chunk = bytes(self.opus_bytes_per_frame)
+        # Encode to OPUS packet
+        opus_bytes = opuslib.api.encoder.encode(
+            self._encoder,
+            audio_chunk,
+            self.opus_frame_size,
+            4000,  # recommended in opus docs
+        )
+        # Add RTP header
+        # See: https://en.wikipedia.org/wiki/Real-time_Transport_Protocol#Packet_header
+        rtp_bytes = struct.pack(
+            ">BBHLL",
+            self._rtp_flags,
+            self.opus_payload_type,
+            self._rtp_sequence_num,
+            self._rtp_timestamp,
+            self._rtp_ssrc,
+        )
+        # Next frame
+        self._rtp_sequence_num += 1
+        self._rtp_timestamp += self.opus_frame_size
+
+        # RTP packet
+        return rtp_bytes + opus_bytes
+
     def process_audio(
         self,
         audio_bytes: bytes,

--- a/voip_utils/util.py
+++ b/voip_utils/util.py
@@ -1,4 +1,5 @@
 """Utilities for VoIP"""
+
 from ipaddress import IPv4Address
 
 

--- a/voip_utils/voip.py
+++ b/voip_utils/voip.py
@@ -4,8 +4,8 @@ import asyncio
 import logging
 import socket
 import struct
-import time
 from abc import ABC, abstractmethod
+from collections.abc import Coroutine
 from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, Optional, Set

--- a/voip_utils/voip.py
+++ b/voip_utils/voip.py
@@ -323,7 +323,7 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
             except asyncio.QueueEmpty:
                 frame = RtpFrame(self.make_silence_frame())
 
-            if self.addr is not None and self.transport is not None:
+            if self._is_connected and self.addr is not None and self.transport is not None:
                 self.transport.sendto(frame.data, self.addr)
                 if frame.finished is not None:
                     _LOGGER.debug("Finished sending audio")

--- a/voip_utils/voip.py
+++ b/voip_utils/voip.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Coroutine
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Optional, Set
+from typing import Any, Callable, Optional, Set, cast
 
 from .const import OPUS_PAYLOAD_TYPE
 from .rtp_audio import RtpOpusInput, RtpOpusOutput
@@ -59,8 +59,8 @@ class VoipDatagramProtocol(SipDatagramProtocol):
         self.valid_protocol_factory = valid_protocol_factory
         self.invalid_protocol_factory = invalid_protocol_factory
         self._tasks: Set[asyncio.Future[Any]] = set()
-        self._rtp_transport: Optional[asyncio.BaseTransport] = None
-        self._rtcp_transport: Optional[asyncio.BaseTransport] = None
+        self._rtp_protocol: Optional[RtpDatagramProtocol] = None
+        self._rtcp_protocol: Optional[RtcpDatagramProtocol] = None
 
     def is_valid_call(self, call_info: CallInfo) -> bool:
         """Filter calls."""
@@ -131,14 +131,14 @@ class VoipDatagramProtocol(SipDatagramProtocol):
     def on_hangup(self, call_info: CallInfo):
         """Handle the end of a call."""
         _LOGGER.debug("Clean up RTP/RTCP resources on hangup")
-        if self._rtcp_transport:
-            _LOGGER.debug("Shutting down RTCP transport")
-            self._rtcp_transport.close()
-            self._rtcp_transport = None
-        if self._rtp_transport:
-            _LOGGER.debug("Shutting down RTP transport")
-            self._rtp_transport.close()
-            self._rtp_transport = None
+        if self._rtcp_protocol:
+            _LOGGER.debug("Shutting down RTCP protocol")
+            self._rtcp_protocol.disconnect()
+            self._rtcp_protocol = None
+        if self._rtp_protocol:
+            _LOGGER.debug("Shutting down RTP protocol")
+            self._rtp_protocol.disconnect()
+            self._rtp_protocol = None
 
     async def _create_rtp_server(
         self,
@@ -153,16 +153,18 @@ class VoipDatagramProtocol(SipDatagramProtocol):
         loop = asyncio.get_running_loop()
 
         # RTCP server
-        self._rtcp_transport, _ = await loop.create_datagram_endpoint(
+        _, rtcp_protocol = await loop.create_datagram_endpoint(
             lambda: RtcpDatagramProtocol(rtcp_state),
             (rtp_ip, rtp_port + 1),
         )
+        self._rtcp_protocol = cast(RtcpDatagramProtocol, rtcp_protocol)
 
         # RTP server
-        self._rtp_transport, _ = await loop.create_datagram_endpoint(
+        _, rtp_protocol = await loop.create_datagram_endpoint(
             partial(protocol_factory, call_info, rtcp_state),
             (rtp_ip, rtp_port),
         )
+        self._rtp_protocol = cast(RtpDatagramProtocol, rtp_protocol)
 
 
 class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
@@ -327,6 +329,7 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
                 self._is_connected
                 and self.addr is not None
                 and self.transport is not None
+                and not self.transport.is_closing()
             ):
                 self.transport.sendto(frame.data, self.addr)
                 if frame.finished is not None:

--- a/voip_utils/voip.py
+++ b/voip_utils/voip.py
@@ -1,4 +1,5 @@
 """Voice over IP (VoIP) implementation."""
+
 import asyncio
 import logging
 import socket
@@ -25,6 +26,15 @@ class RtcpState:
 
 
 CallProtocolFactory = Callable[[CallInfo, RtcpState], asyncio.Protocol]
+
+
+@dataclass
+class AudioOutputChunk:
+    data: bytes
+    rate: int
+    width: int
+    channels: int
+    is_end: bool = False
 
 
 class VoipDatagramProtocol(SipDatagramProtocol):
@@ -157,6 +167,7 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
         channels: int = 1,
         opus_payload_type: int = OPUS_PAYLOAD_TYPE,
         rtcp_state: Optional[RtcpState] = None,
+        create_task: Callable[[Coroutine], asyncio.Task] | None = None,
     ) -> None:
         """Set up RTP server."""
         self.rtcp_state = rtcp_state
@@ -176,11 +187,16 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
         self._audio_queue: "asyncio.Queue[bytes]" = asyncio.Queue()
         self._rtp_input = RtpOpusInput(opus_payload_type=opus_payload_type)
         self._rtp_output = RtpOpusOutput(opus_payload_type=opus_payload_type)
+        self._create_task = create_task or asyncio.create_task
+        self._sender_task = None
+        self._output_audio_queue: asyncio.Queue = asyncio.Queue()
+        self._rtp_queue: asyncio.Queue = asyncio.Queue()
         self._is_connected: bool = False
 
     def disconnect(self):
         self._is_connected = False
         if self.transport is not None:
+            _LOGGER.debug("Closing RTP transport")
             self.transport.close()
             self.transport = None
 
@@ -188,6 +204,10 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
         """Server is ready."""
         self.transport = transport
         self._is_connected = True
+        if self._sender_task is None:
+            _LOGGER.debug("Starting output loop")
+            self._sender_task = self._create_task(self._output_loop())
+            self._sender_task.add_done_callback(self._output_finished)
 
     def datagram_received(self, data, addr):
         """Decode RTP + OPUS into raw audio."""
@@ -234,53 +254,50 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
             _LOGGER.debug("No destination address, can't send audio")
             raise ValueError("Destination address not set")
 
-        bytes_per_sample = width * channels
-        bytes_per_frame = self._rtp_output.opus_frame_size * bytes_per_sample
+        # Add silence before actual audio to allow time for the user to pick up the phone.
+        silence_bytes = bytes(int(rate * silence_before) * width * channels)
+        audio_bytes = silence_bytes + audio_bytes
+        _LOGGER.debug("Adding %s bytes of audio to output queue", len(audio_bytes))
 
-        # Generate all RTP packets up front
-        sample_offset = 0
-        samples_left = len(audio_bytes) // bytes_per_sample
-        rtp_packets: list[bytes] = []
-        while samples_left > 0:
-            _LOGGER.debug("Preparing audio chunk to send")
-            bytes_offset = sample_offset * bytes_per_sample
-            chunk = audio_bytes[bytes_offset : bytes_offset + bytes_per_frame]
-            samples_in_chunk = len(chunk) // bytes_per_sample
-            samples_left -= samples_in_chunk
+        self._output_audio_queue.put_nowait(
+            AudioOutputChunk(audio_bytes, rate, width, channels, False)
+        )
 
-            for rtp_bytes in self._rtp_output.process_audio(
-                chunk,
-                rate,
-                width,
-                channels,
-                is_end=samples_left <= 0,
-            ):
-                rtp_packets.append(rtp_bytes)
+    def make_silence_frame(self):
+        """Make a frame of silence to keep RTP alive."""
+        return self._rtp_output.silence_frame()
 
-            sample_offset += samples_in_chunk
+    async def _output_loop(self) -> None:
+        """Handles scheduling audio output."""
+        loop = asyncio.get_running_loop()
+        next_send = loop.time()
+        while self._is_connected:
+            try:
+                audio = self._output_audio_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            else:
+                _LOGGER.debug("Got audio from output queue")
+                for rtp_bytes in self._rtp_output.process_audio(
+                    audio.data, audio.rate, audio.width, audio.channels, audio.is_end
+                ):
+                    self._rtp_queue.put_nowait(rtp_bytes)
 
-        # Pause before sending to allow time for user to pick up phone.
-        _LOGGER.debug("Pause before sending")
-        time.sleep(silence_before)
+            try:
+                frame = self._rtp_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                frame = self.make_silence_frame()
 
-        # Send RTP in a steady stream, delaying between each packet to simulate real-time audio
-        seconds_per_rtp = self._rtp_output.opus_frame_size / self._rtp_output.opus_rate
-        for rtp_bytes in rtp_packets:
-            if not self._is_connected:
-                break
+            if self.addr is not None and self.transport is not None:
+                self.transport.sendto(frame, self.addr)
 
-            if self.transport is not None:
-                self.transport.sendto(rtp_bytes, addr)
+            # Maintain a fixed 20 ms RTP clock.
+            next_send += 0.020
+            await asyncio.sleep(max(0, next_send - loop.time()))
 
-            # Wait almost the full amount of time for the chunk.
-            #
-            # Sending too fast will cause the phone to skip chunks,
-            # since it doesn't seem to have a very large buffer.
-            #
-            # Sending too slow will cause audio artifacts if there is
-            # network jitter, which is why programs like GStreamer are
-            # much better at this.
-            time.sleep(seconds_per_rtp * sleep_ratio)
+    def _output_finished(self, task: asyncio.Task) -> None:
+        _LOGGER.debug("Clearing sender task")
+        self._sender_task = None
 
 
 class RtcpDatagramProtocol(asyncio.DatagramProtocol, ABC):

--- a/voip_utils/voip.py
+++ b/voip_utils/voip.py
@@ -323,7 +323,11 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
             except asyncio.QueueEmpty:
                 frame = RtpFrame(self.make_silence_frame())
 
-            if self._is_connected and self.addr is not None and self.transport is not None:
+            if (
+                self._is_connected
+                and self.addr is not None
+                and self.transport is not None
+            ):
                 self.transport.sendto(frame.data, self.addr)
                 if frame.finished is not None:
                     _LOGGER.debug("Finished sending audio")

--- a/voip_utils/voip.py
+++ b/voip_utils/voip.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import socket
 import struct
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Coroutine
 from dataclasses import dataclass
@@ -35,6 +36,13 @@ class AudioOutputChunk:
     width: int
     channels: int
     is_end: bool = False
+    finished: threading.Event | None = None
+
+
+@dataclass
+class RtpFrame:
+    data: bytes
+    finished: threading.Event | None = None
 
 
 class VoipDatagramProtocol(SipDatagramProtocol):
@@ -191,6 +199,7 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
         self._sender_task = None
         self._output_audio_queue: asyncio.Queue = asyncio.Queue()
         self._rtp_queue: asyncio.Queue = asyncio.Queue()
+        self._pending_audio_events: set[threading.Event] = set()
         self._is_connected: bool = False
 
     def disconnect(self):
@@ -199,6 +208,10 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
             _LOGGER.debug("Closing RTP transport")
             self.transport.close()
             self.transport = None
+        for event in self._pending_audio_events:
+            event.set()
+
+        self._pending_audio_events.clear()
 
     def connection_made(self, transport):
         """Server is ready."""
@@ -259,9 +272,20 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
         audio_bytes = silence_bytes + audio_bytes
         _LOGGER.debug("Adding %s bytes of audio to output queue", len(audio_bytes))
 
+        finished = threading.Event()
+        self._pending_audio_events.add(finished)
         self._output_audio_queue.put_nowait(
-            AudioOutputChunk(audio_bytes, rate, width, channels, False)
+            AudioOutputChunk(audio_bytes, rate, width, channels, False, finished)
         )
+        _LOGGER.debug("Audio put_nowait completed")
+        # Set timeout to expected audio time plus a 25% margin
+        _LOGGER.debug("Rate %s, width %s, channels %s", rate, width, channels)
+        timeout = (len(audio_bytes) / (rate * width * channels) + 1) * 1.25
+        _LOGGER.debug("Waiting for audio to play with %s second timeout", timeout)
+        if not finished.wait(timeout):
+            _LOGGER.debug("Voip send audio timed out waiting for audio to play")
+        else:
+            _LOGGER.debug("Voip send audio finished sending")
 
     def make_silence_frame(self):
         """Make a frame of silence to keep RTP alive."""
@@ -278,18 +302,33 @@ class RtpDatagramProtocol(asyncio.DatagramProtocol, ABC):
                 pass
             else:
                 _LOGGER.debug("Got audio from output queue")
-                for rtp_bytes in self._rtp_output.process_audio(
-                    audio.data, audio.rate, audio.width, audio.channels, audio.is_end
-                ):
-                    self._rtp_queue.put_nowait(rtp_bytes)
+                rtp = list(
+                    self._rtp_output.process_audio(
+                        audio.data,
+                        audio.rate,
+                        audio.width,
+                        audio.channels,
+                        audio.is_end,
+                    )
+                )
+                for index, rtp_bytes in enumerate(rtp):
+                    is_last = index == len(rtp) - 1
+                    if is_last:
+                        self._rtp_queue.put_nowait(RtpFrame(rtp_bytes, audio.finished))
+                    else:
+                        self._rtp_queue.put_nowait(RtpFrame(rtp_bytes))
 
             try:
                 frame = self._rtp_queue.get_nowait()
             except asyncio.QueueEmpty:
-                frame = self.make_silence_frame()
+                frame = RtpFrame(self.make_silence_frame())
 
             if self.addr is not None and self.transport is not None:
-                self.transport.sendto(frame, self.addr)
+                self.transport.sendto(frame.data, self.addr)
+                if frame.finished is not None:
+                    _LOGGER.debug("Finished sending audio")
+                    frame.finished.set()
+                    self._pending_audio_events.discard(frame.finished)
 
             # Maintain a fixed 20 ms RTP clock.
             next_send += 0.020


### PR DESCRIPTION
Keep RTP output on a consistent schedule and send silence frames when there is no active audio output

This is intended to address https://github.com/home-assistant-libs/voip-utils/issues/49